### PR TITLE
Fixed logging message type check in logit method

### DIFF
--- a/api/apiserver.py
+++ b/api/apiserver.py
@@ -82,7 +82,7 @@ class BaseHandler(tornado.web.RequestHandler):
 
         if message_type == "info":
             logging.info( message )
-        elif message_type == "warning":
+        elif message_type == "warn":
             logging.warn( message )
         elif message_type == "debug":
             logging.debug( message )


### PR DESCRIPTION
Previously, "warn" logging messages would not be logged due to the logit method checking for "warning" but "warn" being passed in.

resolves #4
